### PR TITLE
Additional checks to handle the case where the file already exists

### DIFF
--- a/Kernel/file_utils.cpp
+++ b/Kernel/file_utils.cpp
@@ -2,20 +2,24 @@
 
 
 bool file_utils::create_file_from_buffer(
-	const std::string_view file_path, void* buffer, size_t size
+    const std::string_view file_path, void* buffer, size_t size
 )
 {
-    std::ofstream stream(
-        file_path.data(),
-        std::ios_base::out | std::ios_base::binary
-    );
+    std::ofstream stream(file_path.data(), std::ios::binary);
 
-	if (!stream.write((char*)buffer, size))
-	{
-		stream.close();
-		return false;
-	}
+    if (!stream.is_open())
+    {
+        std::cerr << "Error: Failed to open file '" << file_path.data() << "' for writing." << std::endl;
+        return false;
+    }
 
-	stream.close();
-	return true;
+    if (!stream.write((char*)buffer, size))
+    {
+        std::cerr << "Error: Failed to write data to file '" << file_path.data() << "'." << std::endl;
+        stream.close();
+        return false;
+    }
+
+    stream.close();
+    return true;
 }


### PR DESCRIPTION
This revised version first attempts to open the file for writing using the `std::ofstream` constructor. If the file cannot be opened, it prints an error message to `std::cerr` and returns false.


It then uses the `write `method of the stream to write the contents of the `buffer `to the file, and checks the return value of write to determine if the operation was successful. If the `write `operation fails, it prints an error message to `std::cerr`, closes the stream, and returns `false`.

Finally, the function closes the stream and returns `true `if the file was successfully created and written to.