### PR TITLE
This version of the code includes separate error handling for the creation of each pipe

### DIFF
--- a/Kernel/singed.cpp
+++ b/Kernel/singed.cpp
@@ -10,10 +10,14 @@ CommandResult system_no_output(std::string command) {
   // Create pipes for the child process's STDOUT and STDERR.
   HANDLE stdout_read_handle, stdout_write_handle;
   HANDLE stderr_read_handle, stderr_write_handle;
-  if (!CreatePipe(&stdout_read_handle, &stdout_write_handle, NULL, 0) ||
-      !CreatePipe(&stderr_read_handle, &stderr_write_handle, NULL, 0)) {
-    throw std::runtime_error("Error creating pipes");
+  if (!CreatePipe(&stdout_read_handle, &stdout_write_handle, NULL, 0)) {
+    throw std::runtime_error("Error creating pipe for STDOUT");
   }
+  if (!CreatePipe(&stderr_read_handle, &stderr_write_handle, NULL, 0)) {
+    throw std::runtime_error("Error creating pipe for STDERR");
+  }
+  ...
+}
 
   // Create a new process to execute the command.
   STARTUPINFOA startup_info = {0};


### PR DESCRIPTION
 If the `CreatePipe `function fails to create the pipe for STDOUT, it will throw a `std::runtime_error `with the message "Error creating pipe for STDOUT". If it fails to create the pipe for STDERR, it will throw a `std::runtime_error` with the message "Error creating pipe for STDERR".