### PR TITLE
Changes Made:

### DIFF
--- a/External/core.cpp
+++ b/External/core.cpp
@@ -45,10 +45,10 @@ do {
 } while (false);
 					
 			
-void no_cheat::pawns_loop::add_pawn(const char* pwn, bool(*func)(), bool(*func2)())
+void no_cheat::pawns_loop::add_pawn(const std::string& pwn, std::function<bool()> func, std::function<bool()> func2)
 {
-    std::string pwn_str(pwn);
-    std::wstring wc_str = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(pwn_str);
-    menu.add(wc_str.c_str(), func, func2);
+    std::wstring wc_str = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(pwn);
+    menu.add(wc_str, func, func2);
 }
+
 


### PR DESCRIPTION
- Instead of taking a pointer to a character array, the function now takes a constant reference to a std::string. This allows for the input to be passed by value, and eliminates the need for the string `constructor `and the unnecessary data copy.
- Instead of taking two pointers to functions returning bool and taking no arguments, the function now takes two std::function objects. This is more type-safe and allows for a wider range of callable objects to be passed as arguments, including functors, lambdas, and std::bind expressions.
- The wstring_convert object is not needed to be re-created everytime the function is called, It can be created as a static member of the class.
- The wstring is `constructed `directly from the input string, no need to convert it first to a string and then to a wstring.
- The function is now simpler, safer, and more efficient.